### PR TITLE
Add filter uf_after_register

### DIFF
--- a/inc/action-register.php
+++ b/inc/action-register.php
@@ -143,6 +143,8 @@ function uf_register_new_user( $user_login, $user_email ) {
 	update_user_option( $user_id, 'default_password_nag', true, true ); //Set up the Password change nag.
 
 	wp_new_user_notification( $user_id, $user_pass );
+	
+	apply_filters('uf_after_register', $user_id);
 
 	return $user_id;
 }


### PR DESCRIPTION
This filter provide to add custom meta fields to user meta data or another actions with new registered user.

For example in template user-register.php  add the code. 

``` php
<p><input type="text" name="user_meta[job_title]" placeholder="Job Title*" id="kroll_user_meta__job_title" class="regular-text"></p>
```

And in the function php add 

``` php
function add_reg_fields($user_id) {
    if (isset($_POST['user_meta'])) {
        $user_meta = $_POST['kroll_user_meta'];
        update_user_option( $user_id, 'job_title', $_POST['user_meta']['job_title'], true );
    }
    return $user_id;
}
add_filter('uf_after_register', 'add_reg_fields');
```
